### PR TITLE
Broken header fix

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,4 @@
 = Introduction
-
 :page-aliases: 6.5@server:connectors:elasticsearch-2.1/elastic-intro,6.5@server:connectors:elasticsearch-2.2/overview
 
 The Couchbase Elasticsearch Connector replicates your documents from Couchbase Server to Elasticsearch in near real time.


### PR DESCRIPTION
The blank line after the h1 tag was causing Antora's parsing of the header to end prematurely,
and not reach the page alias.
DOC-6888