### PR TITLE
Add correct indentation for .gradle files to codestyle

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -735,3 +735,7 @@ ij_yaml_sequence_on_new_line = false
 ij_yaml_space_before_colon = false
 ij_yaml_spaces_within_braces = true
 ij_yaml_spaces_within_brackets = true
+
+[*.gradle]
+indent_size = 2
+ij_continuation_indent_size = 4


### PR DESCRIPTION
As I could see there were no codestyle in .editorconfig for *.gradle files, so IDEA's "reformat code" do unexpected changes. This should fix the situation